### PR TITLE
Add watchtower to 'web' network

### DIFF
--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -121,6 +121,8 @@ services:
       - WATCHTOWER_ROLLING_RESTART=true
       - WATCHTOWER_HTTP_API_UPDATE=true
       - WATCHTOWER_HTTP_API_TOKEN=${WATCHTOWER_HTTP_API_TOKEN}
+    networks:
+      - web
 
 volumes:
   data: {}


### PR DESCRIPTION
Watchtower was not in the 'web' network, so traefik could not access it.

This should fix the currently broken webhook.