### PR TITLE
Set tags for production environment to latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,30 +84,6 @@ This environment variable is used to set the database password for the wordpress
 
 Example values: `78sb6g654b56sdv7s89dv` or `as78sdv78sfdv67sdv5dc8sdv09sv`
 
-#### `APP_TAG`
-
-This environment variable is used to set the tag for the carbon case app image.
-
-Example values: `v1.0.0` or `v1.0.0-rc.1`
-
-#### `APP_API_TAG`
-
-This environment variable is used to set the tag for the carbon case app API image.
-
-Example values: `v1.0.0` or `v1.0.0-rc.1`
-
-#### `MANAGEMENT_TAG`
-
-This environment variable is used to set the tag for the carbon case management image.
-
-Example values: `v1.0.0` or `v1.0.0-rc.1`
-
-#### `MANAGEMENT_API_TAG`
-
-This environment variable is used to set the tag for the carbon case management API image.
-
-Example values: `v1.0.0` or `v1.0.0-rc.1`
-
 #### `MSSQL_SA_PASSWORD`
 
 This environment variable is used to set the database system administrator password.

--- a/production/docker-compose.yml
+++ b/production/docker-compose.yml
@@ -49,7 +49,7 @@ services:
 
   app-prd:
     container_name: carboncase-app-prd
-    image: ghcr.io/energietransitie/carboncase-frontend:latest
+    image: ghcr.io/energietransitie/carboncase-frontend:main
     restart: unless-stopped
     labels:
       - traefik.http.routers.carboncase-app-prd.rule=Host(`app.carboncase.energietransitiewindesheim.nl`)
@@ -65,7 +65,7 @@ services:
 
   app-api-prd:
     container_name: carboncase-app-api-prd
-    image: ghcr.io/energietransitie/carboncase-api:latest
+    image: ghcr.io/energietransitie/carboncase-api:main
     restart: unless-stopped
     labels:
       - traefik.http.routers.carboncase-app-api-prd.rule=Host(`api.app.carboncase.energietransitiewindesheim.nl`)
@@ -88,7 +88,7 @@ services:
 
   management-prd:
     container_name: carboncase-management-prd
-    image: ghcr.io/energietransitie/carboncase-management:latest
+    image: ghcr.io/energietransitie/carboncase-management:main
     restart: unless-stopped
     labels:
       - traefik.http.routers.carboncase-management-prd.rule=Host(`dash.carboncase.energietransitiewindesheim.nl`)
@@ -104,7 +104,7 @@ services:
 
   management-api-prd:
     container_name: carboncase-management-prd
-    image: ghcr.io/energietransitie/carboncase-management-api:latest
+    image: ghcr.io/energietransitie/carboncase-management-api:main
     restart: unless-stopped
     labels:
       - traefik.http.routers.carboncase-management-api-prd.rule=Host(`api.dash.carboncase.energietransitiewindesheim.nl`)

--- a/production/docker-compose.yml
+++ b/production/docker-compose.yml
@@ -49,7 +49,7 @@ services:
 
   app-prd:
     container_name: carboncase-app-prd
-    image: ghcr.io/energietransitie/carboncase-frontend:${APP_TAG}
+    image: ghcr.io/energietransitie/carboncase-frontend:latest
     restart: unless-stopped
     labels:
       - traefik.http.routers.carboncase-app-prd.rule=Host(`app.carboncase.energietransitiewindesheim.nl`)
@@ -65,7 +65,7 @@ services:
 
   app-api-prd:
     container_name: carboncase-app-api-prd
-    image: ghcr.io/energietransitie/carboncase-api:${APP_API_TAG}
+    image: ghcr.io/energietransitie/carboncase-api:latest
     restart: unless-stopped
     labels:
       - traefik.http.routers.carboncase-app-api-prd.rule=Host(`api.app.carboncase.energietransitiewindesheim.nl`)
@@ -88,7 +88,7 @@ services:
 
   management-prd:
     container_name: carboncase-management-prd
-    image: ghcr.io/energietransitie/carboncase-management:${MANAGEMENT_TAG}
+    image: ghcr.io/energietransitie/carboncase-management:latest
     restart: unless-stopped
     labels:
       - traefik.http.routers.carboncase-management-prd.rule=Host(`dash.carboncase.energietransitiewindesheim.nl`)
@@ -104,7 +104,7 @@ services:
 
   management-api-prd:
     container_name: carboncase-management-prd
-    image: ghcr.io/energietransitie/carboncase-management-api:${MANAGEMENT_API_TAG}
+    image: ghcr.io/energietransitie/carboncase-management-api:latest
     restart: unless-stopped
     labels:
       - traefik.http.routers.carboncase-management-api-prd.rule=Host(`api.dash.carboncase.energietransitiewindesheim.nl`)


### PR DESCRIPTION
All tags for production are set to `latest`. We need to make sure the containers are built like the following:
- New pushes on the `dev` branch should build a container with tag `dev`. (I still want to remove the dev branch and use `main` and the feature branch workflow).
- New tags will create an image with tags: `<tag name>` and `latest`.

This makes sure that all the newest commits have the tag `dev` (soon `main`), and the released versions (with tags and version numbers and are production ready) have the `latest` tag.

The `dev` tag is used for the test environment.
The `latest` tag is used for the production environment.